### PR TITLE
Make sure Winston always uses the Gtk backend

### DIFF
--- a/src/Gtk/gtkwidget.jl
+++ b/src/Gtk/gtkwidget.jl
@@ -1,10 +1,11 @@
 ## Code that is Gtk specific
 
 ## Plotting code is package dependent
-Requires.@require Winston begin
-    ## need to check this, as we get error otherwise!
-    ENV["WINSTON_OUTPUT"] = :gtk
 
+## need to check this, as we get error otherwise!
+ENV["WINSTON_OUTPUT"] = :gtk
+
+Requires.@require Winston begin
     
     Base.push!(obj::CairoGraphic, pc::Winston.PlotContainer) = Winston.display(obj.obj, pc)
 


### PR DESCRIPTION
The block in the `@require` macro is run after the package was loaded, so the Winston output surface has already been set. I don't think there is any way to change the output surface after Winston was loaded, so the environment variable must be there from the beginning.

Without this fix, the example from the readme fails for me:
```
ERROR: `display` has no method matching display(::GtkCanvas, ::FramedPlot)
 in show_outwidget at /home/matthias/.julia/v0.3/GtkInteract/src/Gtk/gtkwidget.jl:20
 in anonymous at /home/matthias/.julia/v0.3/GtkInteract/src/Gtk/gtkwidget.jl:583
 in display at /home/matthias/.julia/v0.3/GtkInteract/src/Gtk/gtkwidget.jl:583
 in print_response at REPL.jl:139
 in print_response at REPL.jl:124
 in anonymous at REPL.jl:586
 in run_interface at /usr/bin/../lib/julia/sys.so
 in run_frontend at /usr/bin/../lib/julia/sys.so
 in run_repl at /usr/bin/../lib/julia/sys.so
 in _start at /usr/bin/../lib/julia/sys.so
```