### PR TITLE
Changes for new Reactive

### DIFF
--- a/src/Gtk/gtkwidget.jl
+++ b/src/Gtk/gtkwidget.jl
@@ -173,7 +173,7 @@ function gtk_widget(widget::Checkbox)
         push!(widget.signal, getproperty(obj, :active, Bool))
     end
 
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(obj, id)
         setproperty!(obj, :active, val)
         signal_handler_unblock(obj, id)
@@ -197,7 +197,7 @@ function gtk_widget(widget::Slider)
     end
     
     ## 
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(obj, id)
         Gtk.G_.value(obj, val)
         signal_handler_unblock(obj, id)
@@ -219,7 +219,7 @@ function gtk_widget(widget::ToggleButton)
     end
 
     ## signal -> widget
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(obj, id)
         setproperty!(obj, :active, val)
         signal_handler_unblock(obj, id)
@@ -243,7 +243,7 @@ function gtk_widget(widget::Textbox)
 
     
     ## signal -> widget
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(obj, id)
         setproperty!(obj, :text, string(val))
         signal_handler_unblock(obj, id)
@@ -268,7 +268,7 @@ function gtk_widget(widget::Options{:Dropdown})
     end
 
     ## signal -> widget
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(obj, id)
         index = getproperty(obj, :active, Int) + 1
         val = findfirst(collect(values(widget.options)), val)
@@ -310,7 +310,7 @@ function gtk_widget(widget::Options{:RadioButtons})
     showall(obj)
 
     ## signal -> widget
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         [signal_handler_block(btn, id) for (btn,id) in ids]
         selected = findfirst(collect(values(widget.options)), val)
         setproperty!(btns[selected], :active, true)
@@ -354,7 +354,7 @@ function gtk_widget(widget::Options{:ToggleButtons})
     end
 
     ## signal -> widget
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         ## get index from val
         index = findfirst(vals, val)
         lab = labs[index]
@@ -403,7 +403,7 @@ function gtk_widget(widget::VectorOptions{:ButtonGroup})
     end
 
     ## signal -> widget
-    lift(widget.signal) do values
+    foreach(widget.signal) do values
         
         indices = [findfirst(vals, v) for v in values]
         selectedlabs = labs[indices]
@@ -461,7 +461,7 @@ function gtk_widget(widget::Options{:Select})
     end
     
     ## push! -> update UI
-    lift(widget.signal) do val
+    foreach(widget.signal) do val
         signal_handler_block(selection, id)
         index = findfirst(vals, val)
         iter = Gtk.iter_from_index(store, index)
@@ -628,7 +628,7 @@ Base.append!(parent::MainWindow, items) = map(x -> push!(parent, x), items)
 
 
 ## for displaying an @manipulate object, we need this
-Base.display(x::ManipulateWidget) = lift(a -> show_outwidget(x.w, a), x.a)
+Base.display(x::ManipulateWidget) = foreach(a -> show_outwidget(x.w, a), x.a)
 
 function show_outwidget(w, x)
     x == nothing && return()

--- a/src/GtkInteract.jl
+++ b/src/GtkInteract.jl
@@ -137,8 +137,6 @@ function progress(;label="", value=0, range=0:100)
     Progress(nothing, value, range, nothing)
 end
 
-Reactive.signal(x::Widget) = x.signal
-
 ## We add these output widgets to `widget`
 widget_dict = Dict{Symbol, Function}()
 widget_dict[:plot]=cairographic
@@ -208,7 +206,7 @@ macro manipulate(expr)
     w = mainwindow(title="@manipulate")
     a = Expr(:let, Expr(:block,
                         display_widgets(w, syms)...,
-                        esc(Interact.lift_block(block, syms))),
+                        esc(Interact.map_block(block, syms))),
              map(Interact.make_widget, bindings)...)
 
     b = Expr(:call, :ManipulateWidget, a, w)


### PR DESCRIPTION
Depends on Interact master (let's release the two in lock-step, but I still need to test Interact with IJulia)

I'm running into a segfault with this simple example when I move the slider. But works when I use the toggle buttons.


```
julia>
@manipulate for ϕ = 0:π/16:4π, f = Dict(:sin=>sin, :cos=>cos)
           ϕ, f
       end

julia> 
signal (11): Segmentation fault
unknown function (ip: 0x7fd9a590f178)
g_signal_emit_valist at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so (unknown line)
g_signal_emit at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so (unknown line)
unknown function (ip: 0x7fd9a5902725)
g_object_notify at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so (unknown line)
unknown function (ip: 0x7fd9a4da9b6f)
unknown function (ip: 0x7fd9a4c1d078)
unknown function (ip: 0x7fd9a4c1d47a)
gtk_label_set_label at /usr/lib/x86_64-linux-gnu/libgtk-3.so.0 (unknown line)
g_object_set_property at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so (unknown line)
setproperty! at /home/shashi/.julia/v0.4/Gtk/src/GLib/gvalues.jl:163
jl_apply_generic at /home/shashi/code/julia/4/usr/bin/../lib/libjulia.so (unknown line)
show_outwidget at /home/shashi/.julia/v0.4/GtkInteract/src/Gtk/gtkwidget.jl:642
jl_apply_generic at /home/shashi/code/julia/4/usr/bin/../lib/libjulia.so (unknown line)
anonymous at /home/shashi/.julia/v0.4/GtkInteract/src/Gtk/gtkwidget.jl:631
jl_f_apply at /home/shashi/code/julia/4/usr/bin/../lib/libjulia.so (unknown line)
anonymous at /home/shashi/.julia/v0.4/Reactive/src/operators.jl:36
do_action at /home/shashi/.julia/v0.4/Reactive/src/core.jl:135
jlcall_do_action_22136 at  (unknown line)
jl_apply_generic at /home/shashi/code/julia/4/usr/bin/../lib/libjulia.so (unknown line)
send_value! at /home/shashi/.julia/v0.4/Reactive/src/core.jl:130
```

partially addresses #5