### PR TITLE
Made a small change so that @manipulate can be used with Winston.Table

### DIFF
--- a/src/Gtk/gtkwidget.jl
+++ b/src/Gtk/gtkwidget.jl
@@ -90,7 +90,7 @@ end
 Requires.@require Winston begin
     ENV["WINSTON_OUTPUT"] = :gtk    
 
-    show_outwidget(w::GtkInteract.MainWindow, x::Winston.FramedPlot) = make_canvas(w, x)
+    show_outwidget(w::GtkInteract.MainWindow, x::Winston.PlotContainer) = make_canvas(w, x)
     
     function Base.push!(obj::CairoGraphic, pc::Winston.PlotContainer)
         if obj.obj != nothing


### PR DESCRIPTION
I'm using GtkInteract to pan through data that are plotted using Winston.Table. This change allows that by allowing show_outwidget to be called with Winston.Table as the second argument.