### PR TITLE
Fix numeric-valued textboxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+sudo: false
+os:
+    - linux
+julia:
+    - 0.4
+    - nightly
 notifications:
-  email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    email: false
+addons:
+    apt:
+        packages:
+            - xvfb
+            - xauth
+            - libgtk-3-0
 script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("GtkInteract")'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - xvfb-run julia -e 'Pkg.clone(pwd()); Pkg.test("Gtk"; coverage=true)'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,3 +42,17 @@ w = window(vbox(controls...), hbox(halign(:end,padding(10, btn))))
 ##           $(string(bg))
 ##           """)  #          $(string(sel))
 ## end
+
+# test numeric-valued textboxes
+using Gtk, Interact
+w = mainwindow()
+b = textbox(1)
+push!(w, b)
+display(w)
+g = first(w.window)
+widget = first(g)
+setproperty!(widget, :text, "2")
+@test value(signal(b)) == 1
+signal_emit(widget, :activate, Void)
+sleep(0.1)
+@test value(signal(b)) == 2


### PR DESCRIPTION
Previously, creating a textbox as `textbox(1)` and then entering a new value into it would fail with the error message
```jl
to node
    WeakRef(Signal{Int64}(1, nactions=1))
MethodError: Cannot `convert` an object of type String to an object of type Int64
This may have arisen from a call to the constructor Int64(...),
since type constructors fall back to convert methods.
 in send_value!(::Reactive.Signal{Int64}, ::String, ::Int64) at /home/tim/.julia/v0.5/Reactive/src/core.jl:128
 [inlined code] from ./bool.jl:16
 in send_value!(::WeakRef, ::String, ::Int64) at /home/tim/.julia/v0.5/Reactive/src/core.jl:133
 in run(::Int64) at /home/tim/.julia/v0.5/Reactive/src/core.jl:197
 [inlined code] from /home/tim/.julia/v0.5/Reactive/src/core.jl:235
 in (::Reactive.##12#14)() at ./task.jl:308
```
This makes use of Interact's `parse_msg` to convert to numeric type when appropriate.

Also, this restores the "simple" `signal_connect` syntax, fixed by @vtjnash a few days ago, and switches to the `:activate` signal (meaning, it updates when the user hits "enter.") Doing it on a key-by-key basis is prone to trouble if, for example, you have a numeric textbox and want to enter a negative number---parsing complains about an isolated `-` being interpreted as a number.

Finally, the new test seems to require opening the display so the widgets are generated---we use them as a back-door to simulate entering text into the entry box. In hopes of making the travis tests pass, I added usage of `xvfb`.

emacs has also deleted a lot of whitespace; you may know that you can append `?w=1` to the URL and it will suppress whitespace changes. Might make it easier to review this.