### PR TITLE
Fixed the canvas clear using immerse

### DIFF
--- a/src/Gtk/gtkwidget.jl
+++ b/src/Gtk/gtkwidget.jl
@@ -103,8 +103,10 @@ Requires.@require Immerse begin
     end
 
     function Base.push!(obj::CairoGraphic, p::Gadfly.Plot)
-        if obj.obj != nothing
-            push!(obj.obj, p)
+        canvas = obj.obj
+        if canvas != nothing
+            canvas.back = Gtk.cairo_surface_for(canvas)
+            push!(canvas, p)
         end
     end
 end


### PR DESCRIPTION
According to #16
It is possible to add `canvas.backcc = Gtk.CairoContext(canvas.back)` before push!, bit I am not sure what it does, and it doesn't seem to be needed.